### PR TITLE
github actions maven snyk and sonar

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -28,8 +28,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: snyk/actions/maven-3-jdk-11@master
+        continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --sarif-file-output=snyk.sarif
+      - uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: snyk.sarif
   # According to Sonar documentation[1] active branches are detected automatically when running with a GitHub Action.
   # Though to make configuration work running locally with act[2] as well, extracting the name explicitly is necessary.
   #

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
+          cache: maven
       - run: mvn -v
       - run: mvn -B verify
   security:

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -22,7 +22,10 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - run: mvn -v
-      - run: mvn -B verify
+      - run: mvn -B package
+      - uses: actions/upload-artifact@v2
+        with:
+           path: target/*.jar
   security:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -52,7 +52,7 @@ jobs:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
-      - run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Pcoverage
+      - run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
         env:
           # Needed to get some information about the pull request, if any
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -27,21 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/maven@master
-        continue-on-error: true # To make sure we continue to the upload step, even when vulnerabilities are detected.
+      - uses: snyk/actions/maven-3-jdk-11@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          args: snyk test --sarif-file-output=snyk.sarif
-      - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          sarif_file: snyk.sarif
-          category: Snyk
   # According to Sonar documentation[1] active branches are detected automatically when running with a GitHub Action.
   # Though to make configuration work running locally with act[2] as well, extracting the name explicitly is necessary.
   #

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -47,16 +47,13 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
-          java-version: 11
-      - name: Extract branch name
-        shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-        id: extract_branch
+          java-version: '11'
+          distribution: 'adopt'
+          cache: maven
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./mvnw -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.branch.name=${{ steps.extract_branch.outputs.branch }}
+        run: mvn -B org.sonarsource.scanner.maven:sonar-maven-plugin:sonar

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: maven
       - run: mvn -v
       - run: mvn -B verify
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: maven
       - uses: actions/cache@v1
         with:

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -15,12 +15,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Git checkout
-        uses: actions/checkout@v2
-      - name: Branch name
-        run: echo running on branch ${GITHUB_REF##*/}
-      - name: Build
-        run: ./mvnw -B package 
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+          with:
+            java-version: '11'
+            distribution: 'adopt'
+      - run: mvn -v
+      - run: mvn -B verify
   security:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -17,9 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
-          with:
-            java-version: '11'
-            distribution: 'adopt'
+        with:
+          java-version: '11'
+          distribution: 'adopt'
       - run: mvn -v
       - run: mvn -B verify
   security:

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -52,7 +52,7 @@ jobs:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
-      - run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+      - run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Pcoverage
         env:
           # Needed to get some information about the pull request, if any
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -36,11 +36,6 @@ jobs:
       - uses: github/codeql-action/upload-sarif@v1
         with:
           sarif_file: snyk.sarif
-  # According to Sonar documentation[1] active branches are detected automatically when running with a GitHub Action.
-  # Though to make configuration work running locally with act[2] as well, extracting the name explicitly is necessary.
-  #
-  # [1] https://docs.sonarqube.org/latest/branches/overview/#header-2
-  # [2] https://github.com/nektos/act
   analysis:
     runs-on: ubuntu-latest
     steps:
@@ -52,8 +47,14 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
           cache: maven
-      - name: Build and analyze
+      - uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Pcoverage
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          # Needed to get some information about the pull request, if any
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # SonarCloud access token should be generated from https://sonarcloud.io/account/security/
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B org.sonarsource.scanner.maven:sonar-maven-plugin:sonar

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -12,6 +12,15 @@ on:
       - reopened
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+      - name: Branch name
+        run: echo running on branch ${GITHUB_REF##*/}
+      - name: Build
+        run: ./mvnw -B package 
   security:
     runs-on: ubuntu-latest
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     The two following properties are displayed on your project
     at https://sonarcloud.io
      -->
-    <sonar.organization>devoxx4kids</sonar.organization>
+    <sonar.organization>tubbynl</sonar.organization>
     <sonar.projectKey>littil-backend</sonar.projectKey>
   </properties>
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,13 @@
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>2.6.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+    <!-- 
+    The two following properties are displayed on your project
+    at https://sonarcloud.io
+     -->
+    <sonar.organization>Devoxx4Kids-NPO</sonar.organization>
+    <sonar.projectKey>littil-backend</sonar.projectKey>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,21 @@
         </configuration>
       </plugin>
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.8.5</version>
+        </plugin>
+        <plugin>
+          <groupId>org.sonarsource.scanner.maven</groupId>
+          <artifactId>sonar-maven-plugin</artifactId>
+          <!-- see versions at https://search.maven.org/search?q=g:org.sonarsource.scanner.maven%20AND%20a:sonar-maven-plugin -->
+          <version>3.9.1.2184</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
   <profiles>
     <profile>
@@ -157,6 +172,31 @@
       <properties>
         <quarkus.package.type>native</quarkus.package.type>
       </properties>
+    </profile>
+    <profile>
+      <id>coverage</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>prepare-agent</id>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>report</id>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     The two following properties are displayed on your project
     at https://sonarcloud.io
      -->
-    <sonar.organization>Devoxx4Kids-NPO</sonar.organization>
+    <sonar.organization>devoxx4kids</sonar.organization>
     <sonar.projectKey>littil-backend</sonar.projectKey>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
add build steps
- [x] maven build
- [x] maven artifact publish
- [x] snyk check
- [x] snyk report uploaded as github 'Code scanning alerts'
- [ ] sonarqube check
- [ ] sonarqube report

for Snyk it requires the Snyk auth token to be added as Github action secret ( Settings -> Secrets -> New Repository Secret; name = SNYK_TOKEN )

@pschildkamp SonarQube is non-functional; i think most settings / config is there. But i can't create a correct "Organisation"

it fails (locally and on github actions) with
```
[ERROR] Failed to execute goal org.sonarsource.scanner.maven:sonar-maven-plugin:3.9.1.2184:sonar (default-cli) on project backend: You're not authorized to run analysis. Please contact the project administrator. -> [Help 1]
```
most config is handled with maven properties, only the `SONAR_TOKEN` is expected to be a env var and valid
