### PR TITLE
Replace mysql with mariadb

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-jdbc-mysql</artifactId>
+      <artifactId>quarkus-jdbc-mariadb</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,6 @@ greeting:
 
 quarkus:
   datasource:
-    db-kind: h2
+    db-kind: mariadb
     devservices:
       enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,3 +6,6 @@ quarkus:
     db-kind: mariadb
     devservices:
       enabled: true
+  hibernate-orm:
+    database:
+      generation: update


### PR DESCRIPTION
vervangen mysql door mariadb

* had ik lokaal nodig omdat mysql geen ARM varianten heeft (ik draai Apple M1) en mariadb slikt dat wel :)
* mariadb is een drop-in voor mysql varianten; destijds een fork van mysql want oracle enzo.
* cloud providers als ze mysql aanbieden zal dat meestal ook een mariadb zijn ivm licenties

daarnaast een fix omdat er geen changelogs zijn heb ik de schema-update op update gezet
