### PR TITLE
Generate openapi files (yaml|json) in build step @ target/generated

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,6 +6,8 @@ quarkus:
       generation: none
   log:
     level: INFO
+  smallrye-openapi:
+    store-schema-directory: "target/generated"
 
 "%dev":
   quarkus:


### PR DESCRIPTION
As requested by @jaspersprengers this change will make sure the openapi spec will be generated in the buildstep.
The files in Yaml en Json format can be found in the target/generated directory.