### PR TITLE
LITTIL-165 Improve accuracy of Coordinates API

### DIFF
--- a/src/main/java/org/littil/api/coordinates/service/CoordinatesService.java
+++ b/src/main/java/org/littil/api/coordinates/service/CoordinatesService.java
@@ -17,12 +17,12 @@ public class CoordinatesService {
     @RestClient
     SearchService coordinatesService;
 
-    public Optional<Coordinates> getCoordinates(@NotEmpty final String postalCode, @NotEmpty final String address) {
-        final Set<Coordinates> coordinatesSet = coordinatesService.getCoordinatesByAddress(postalCode, address, "json");
-
+    public Optional<Coordinates> getCoordinates(@NotEmpty final String postalCode) {
+        final Set<Coordinates> coordinatesSet = coordinatesService.getCoordinatesByAddress(postalCode, "json");
+        
         if (coordinatesSet.isEmpty()) {
-            log.warn(String.format("Coordinates could not be fetched with postal code: %s and address: %s." +
-                    "This implies this address will not be found when searching within a radius.", postalCode, address));
+            log.warn(String.format("Coordinates could not be fetched with postal code: %s." +
+                    "This implies this address will not be found when searching within a radius.", postalCode));
         }
 
         return coordinatesSet.stream().findFirst();

--- a/src/main/java/org/littil/api/coordinates/service/SearchService.java
+++ b/src/main/java/org/littil/api/coordinates/service/SearchService.java
@@ -11,7 +11,6 @@ public interface SearchService {
 
     @GET
     Set<Coordinates> getCoordinatesByAddress(
-            @QueryParam("postal_code") String postalCode,
-            @QueryParam("street") String street,
-            @QueryParam("format") String format );
+            @QueryParam("q") String query,
+            @QueryParam("format") String format);
 }

--- a/src/main/java/org/littil/api/location/repository/LocationEntityListener.java
+++ b/src/main/java/org/littil/api/location/repository/LocationEntityListener.java
@@ -18,7 +18,7 @@ public class LocationEntityListener {
     @PrePersist
     @PreUpdate
     public void prePersistOrUpdate(final LocationEntity location) {
-        final Optional<Coordinates> coordinates = coordinatesService.getCoordinates(location.getPostalCode(), location.getAddress());
+        final Optional<Coordinates> coordinates = coordinatesService.getCoordinates(location.getPostalCode());
         coordinates.ifPresent(c -> {
             location.setLatitude(c.getLat());
             location.setLongitude(c.getLon());

--- a/src/test/java/org/littil/api/coordinates/service/CoordinatesServiceTest.java
+++ b/src/test/java/org/littil/api/coordinates/service/CoordinatesServiceTest.java
@@ -21,33 +21,24 @@ class CoordinatesServiceTest {
 
     @Test
     void givenGetCoordinates_thenShouldReturnCoordinates() {
-        Optional<Coordinates> coordinates = service.getCoordinates("1234AB", "Address");
+        Optional<Coordinates> coordinates = service.getCoordinates("1234AB");
         assertThat(coordinates).isPresent();
     }
 
     @Test
     void givenGetCoordinatesNotFound_thenShouldNotBreakPersistenceFlow() {
-        Optional<Coordinates> coordinates = service.getCoordinates("1234AB", WireMockSearchService.NOT_FOUND);
+        Optional<Coordinates> coordinates = service.getCoordinates(WireMockSearchService.NOT_FOUND);
         assertThat(coordinates).isNotNull();
     }
 
     @Test
     void givenGetCoordinatesWithNullPostalCode_thenShouldThrowConstraintViolationException() {
-        assertThrows(ConstraintViolationException.class, () -> service.getCoordinates(null, "address"));
+        assertThrows(ConstraintViolationException.class, () -> service.getCoordinates(null));
     }
 
     @Test
     void givenGetCoordinatesWithBlankPostalCode_thenShouldThrowConstraintViolationException() {
-        assertThrows(ConstraintViolationException.class, () -> service.getCoordinates("", "address"));
+        assertThrows(ConstraintViolationException.class, () -> service.getCoordinates(""));
     }
 
-    @Test
-    void givenGetCoordinatesWithBlankAddress_thenShouldThrowConstraintViolationException() {
-        assertThrows(ConstraintViolationException.class, () -> service.getCoordinates("1234AB", ""));
-    }
-
-    @Test
-    void givenGetCoordinatesWithNullAddress_thenShouldThrowConstraintViolationException() {
-        assertThrows(ConstraintViolationException.class, () -> service.getCoordinates("1234AB", null));
-    }
 }

--- a/src/test/java/org/littil/api/guestTeacher/api/GuestTeacherResourceTest.java
+++ b/src/test/java/org/littil/api/guestTeacher/api/GuestTeacherResourceTest.java
@@ -13,13 +13,12 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.littil.api.auth.service.AuthenticationService;
-import org.littil.api.coordinates.service.Coordinates;
-import org.littil.api.coordinates.service.CoordinatesService;
 import org.littil.api.exception.ErrorResponse;
 import org.littil.api.guestTeacher.service.GuestTeacher;
 import org.littil.api.user.service.User;
 import org.littil.api.user.service.UserService;
 import org.littil.mock.auth0.APIManagementMock;
+import org.littil.mock.coordinates.service.WireMockSearchService;
 
 import java.time.DayOfWeek;
 import java.util.EnumSet;
@@ -38,13 +37,11 @@ import static org.mockito.Mockito.doReturn;
 @QuarkusTest
 @TestHTTPEndpoint(GuestTeacherResource.class)
 @QuarkusTestResource(APIManagementMock.class)
+@QuarkusTestResource(WireMockSearchService.class)
 class GuestTeacherResourceTest {
 
     @InjectSpy
     UserService userService;
-
-    @InjectMock
-    CoordinatesService coordinatesService;
 
     @InjectMock
     AuthenticationService authenticationService;
@@ -295,12 +292,6 @@ class GuestTeacherResourceTest {
     private GuestTeacher saveTeacher(GuestTeacherPostResource teacher) {
         User createdUser = createAndSaveUser();
         doReturn(Optional.ofNullable(createdUser)).when(userService).getUserById(any(UUID.class));
-
-        Coordinates coordinates = Coordinates.builder()
-                .lat(0.0)
-                .lon(0.0)
-                .build();
-        doReturn(Optional.of(coordinates)).when(coordinatesService).getCoordinates(any(), any());
 
         doNothing().when(authenticationService).addAuthorization(any(),any(), any());
 

--- a/src/test/java/org/littil/api/school/api/SchoolResourceTest.java
+++ b/src/test/java/org/littil/api/school/api/SchoolResourceTest.java
@@ -13,13 +13,12 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.littil.api.auth.service.AuthenticationService;
-import org.littil.api.coordinates.service.Coordinates;
-import org.littil.api.coordinates.service.CoordinatesService;
 import org.littil.api.exception.ErrorResponse;
 import org.littil.api.school.service.School;
 import org.littil.api.user.service.User;
 import org.littil.api.user.service.UserService;
 import org.littil.mock.auth0.APIManagementMock;
+import org.littil.mock.coordinates.service.WireMockSearchService;
 
 import java.util.List;
 import java.util.Optional;
@@ -36,13 +35,11 @@ import static org.mockito.Mockito.doReturn;
 @QuarkusTest
 @TestHTTPEndpoint(SchoolResource.class)
 @QuarkusTestResource(APIManagementMock.class)
+@QuarkusTestResource(WireMockSearchService.class)
 class SchoolResourceTest {
     
     @InjectSpy
     UserService userService;
-    
-    @InjectMock
-    CoordinatesService coordinatesService;
     
     @InjectMock
     AuthenticationService authenticationService;
@@ -309,13 +306,7 @@ class SchoolResourceTest {
         User createdUser = createAndSaveUser();
         doReturn(Optional.ofNullable(createdUser)).when(userService).getUserById(any(UUID.class));
 
-        Coordinates coordinates = Coordinates.builder() //
-                .lat(0.0) //
-                .lon(0.0) //
-                .build();
-        doReturn(Optional.of(coordinates)).when(coordinatesService).getCoordinates(any(), any());
-
-        doNothing().when(authenticationService).addAuthorization(any(), any(), any());
+         doNothing().when(authenticationService).addAuthorization(any(), any(), any());
 
         return given()
                 .contentType(ContentType.JSON)


### PR DESCRIPTION
Changed nominate API to use query parameter q=<query> where query holds the postal code. As a result there are no falls coordinates in the result set.