### PR TITLE
Enabled CORS and whitelisted the NG frontend for dev

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,6 +17,8 @@ org:
           id: ${M2M_CLIENT_ID:m2m_client_id}
           secret: ${M2M_CLIENT_SECRET:m2m_client_secret}
 quarkus:
+  http:
+    cors: true
   datasource:
     db-kind: mariadb
   hibernate-orm:
@@ -61,6 +63,9 @@ quarkus:
       devservices:
         devdata: true
   quarkus:
+    http:
+      cors:
+        origins: http://localhost:4200,http://localhost:8080
     datasource:
       devservices:
         port: 61052


### PR DESCRIPTION
Fix for the frontend team that the backend accepts requests from localhost:4200 when running in development mode.