### PR TITLE
vulnerability in jose4j (via quarkus-oidc)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,11 @@
             <artifactId>graal-sdk</artifactId>
             <version>22.3.2</version>
         </dependency>
+        <dependency><!-- override jose4j because of vulnerability in version 0.9.2 (via quarkus-oidc) -->
+            <groupId>org.bitbucket.b_c</groupId>
+            <artifactId>jose4j</artifactId>
+            <version>0.9.3</version>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-flyway</artifactId>


### PR DESCRIPTION
fix for following issue ?

Upgrade io.quarkus:quarkus-oidc@2.16.6.Final to io.quarkus:quarkus-oidc@3.0.0.Final to fix
  ✗ Use of a Broken or Risky Cryptographic Algorithm (new) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGBITBUCKETBC-5488281] in org.bitbucket.b_c:jose4j@0.9.2
    introduced by io.quarkus:quarkus-oidc@2.16.6.Final > io.smallrye:smallrye-jwt@3.6.0 > org.bitbucket.b_c:jose4j@0.9.2
