### PR TITLE
Fix for disabled unit tests

### DIFF
--- a/src/test/java/org/littil/api/contact/api/ContactResourceTest.java
+++ b/src/test/java/org/littil/api/contact/api/ContactResourceTest.java
@@ -3,7 +3,7 @@ package org.littil.api.contact.api;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.mockito.InjectMock;
+import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.mockito.InjectSpy;
 import io.quarkus.test.security.TestSecurity;
 import io.quarkus.test.security.oidc.Claim;

--- a/src/test/java/org/littil/api/exception/ThrowableMapperTest.java
+++ b/src/test/java/org/littil/api/exception/ThrowableMapperTest.java
@@ -2,7 +2,7 @@ package org.littil.api.exception;
 
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.mockito.InjectMock;
+import io.quarkus.test.InjectMock;
 import io.quarkus.test.security.TestSecurity;
 import io.quarkus.test.security.oidc.Claim;
 import io.quarkus.test.security.oidc.OidcSecurity;

--- a/src/test/java/org/littil/api/guestTeacher/api/GuestTeacherModuleResourceTest.java
+++ b/src/test/java/org/littil/api/guestTeacher/api/GuestTeacherModuleResourceTest.java
@@ -3,8 +3,9 @@ package org.littil.api.guestTeacher.api;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.mockito.InjectMock;
+import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.mockito.InjectSpy;
+import io.quarkus.test.junit.mockito.MockitoConfig;
 import io.quarkus.test.security.TestSecurity;
 import io.quarkus.test.security.oidc.Claim;
 import io.quarkus.test.security.oidc.OidcSecurity;
@@ -50,7 +51,8 @@ public class GuestTeacherModuleResourceTest
     TokenHelper tokenHelper;
     @InjectMock
     AuthenticationService authenticationService;
-    @InjectMock(convertScopes=true)
+    @InjectMock
+    @MockitoConfig(convertScopes=true)
     GuestTeacherSecurityInterceptor guestTeacherSecurityInterceptor;
 
     @BeforeEach

--- a/src/test/java/org/littil/api/guestTeacher/api/GuestTeacherResourceTest.java
+++ b/src/test/java/org/littil/api/guestTeacher/api/GuestTeacherResourceTest.java
@@ -3,14 +3,13 @@ package org.littil.api.guestTeacher.api;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.mockito.InjectMock;
+import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.mockito.InjectSpy;
 import io.quarkus.test.security.TestSecurity;
 import io.quarkus.test.security.oidc.Claim;
 import io.quarkus.test.security.oidc.OidcSecurity;
 import io.restassured.http.ContentType;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.littil.TestFactory;
 import org.littil.api.auth.TokenHelper;
@@ -229,12 +228,11 @@ class GuestTeacherResourceTest {
     @TestSecurity(user = "littil", roles = "viewer")
     @OidcSecurity(claims = {
             @Claim(key = "https://littil.org/littil_user_id", value = "0ea41f01-cead-4309-871c-c029c1fe19bf")})
-    @Disabled("fails on 401, my guess wrongly mocked")
     void givenDeleteTeacherById_thenShouldDeleteSuccessfully() {
         GuestTeacherPostResource teacher = getGuestTeacherPostResource();
         GuestTeacher saved = saveTeacher(teacher);
 
-        doReturn(withGuestTeacherAuthorization(saved.getId())).when(tokenHelper).getCustomClaim(any());
+        doReturn(withGuestTeacherAuthorization(saved.getId())).when(tokenHelper).getAuthorizations();
 
         given()
                 .contentType(ContentType.JSON)

--- a/src/test/java/org/littil/api/guestTeacher/service/GuestTeacherModuleServiceTest.java
+++ b/src/test/java/org/littil/api/guestTeacher/service/GuestTeacherModuleServiceTest.java
@@ -2,7 +2,7 @@ package org.littil.api.guestTeacher.service;
 
 import io.quarkus.security.UnauthorizedException;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.mockito.InjectMock;
+import io.quarkus.test.InjectMock;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
 import org.littil.api.auth.TokenHelper;

--- a/src/test/java/org/littil/api/guestTeacher/service/GuestTeacherServiceTest.java
+++ b/src/test/java/org/littil/api/guestTeacher/service/GuestTeacherServiceTest.java
@@ -1,7 +1,7 @@
 package org.littil.api.guestTeacher.service;
 
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.mockito.InjectMock;
+import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.mockito.InjectSpy;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/littil/api/school/api/SchoolModuleResourceTest.java
+++ b/src/test/java/org/littil/api/school/api/SchoolModuleResourceTest.java
@@ -3,8 +3,9 @@ package org.littil.api.school.api;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.mockito.InjectMock;
+import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.mockito.InjectSpy;
+import io.quarkus.test.junit.mockito.MockitoConfig;
 import io.quarkus.test.security.TestSecurity;
 import io.quarkus.test.security.oidc.Claim;
 import io.quarkus.test.security.oidc.OidcSecurity;
@@ -51,7 +52,8 @@ public class SchoolModuleResourceTest
     TokenHelper tokenHelper;
     @InjectMock
     AuthenticationService authenticationService;
-    @InjectMock(convertScopes=true)
+    @InjectMock
+    @MockitoConfig(convertScopes=true)
     SchoolSecurityInterceptor schoolSecurityInterceptor;
 
     @BeforeEach

--- a/src/test/java/org/littil/api/school/api/SchoolResourceTest.java
+++ b/src/test/java/org/littil/api/school/api/SchoolResourceTest.java
@@ -3,14 +3,13 @@ package org.littil.api.school.api;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.mockito.InjectMock;
+import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.mockito.InjectSpy;
 import io.quarkus.test.security.TestSecurity;
 import io.quarkus.test.security.oidc.Claim;
 import io.quarkus.test.security.oidc.OidcSecurity;
 import io.restassured.http.ContentType;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.littil.TestFactory;
 import org.littil.api.auth.TokenHelper;
@@ -276,18 +275,18 @@ class SchoolResourceTest {
     @TestSecurity(user = "littil", roles = "schools")
     @OidcSecurity(claims = {
             @Claim(key = "https://littil.org/littil_user_id", value = "0ea41f01-cead-4309-871c-c029c1fe19bf") })
-    @Disabled("fails on 401, my guess wrongly mocked")
     void givenDeleteSchoolById_thenShouldDeleteSuccessfully() {
         SchoolPostResource school = getDefaultSchool();
         School savedSchool = saveSchool(school);
 
-        doReturn(withSchoolAuthorization(savedSchool.getId())).when(tokenHelper).getCustomClaim(any());
+        doReturn(withSchoolAuthorization(savedSchool.getId())).when(tokenHelper).getAuthorizations();
 
         given()
                 .contentType(ContentType.JSON)
                 .delete("/{id}", savedSchool.getId())
                 .then()
-                .statusCode(200);
+                .statusCode(200)
+        ;
 
         given()
                 .contentType(ContentType.JSON)

--- a/src/test/java/org/littil/api/school/service/SchoolModuleServiceTest.java
+++ b/src/test/java/org/littil/api/school/service/SchoolModuleServiceTest.java
@@ -2,7 +2,7 @@ package org.littil.api.school.service;
 
 import io.quarkus.security.UnauthorizedException;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.mockito.InjectMock;
+import io.quarkus.test.InjectMock;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
 import org.littil.api.auth.TokenHelper;

--- a/src/test/java/org/littil/api/school/service/SchoolServiceTest.java
+++ b/src/test/java/org/littil/api/school/service/SchoolServiceTest.java
@@ -2,7 +2,7 @@ package org.littil.api.school.service;
 
 import io.quarkus.security.UnauthorizedException;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.mockito.InjectMock;
+import io.quarkus.test.InjectMock;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
 import org.littil.TestFactory;

--- a/src/test/java/org/littil/api/search/service/SearchServiceTest.java
+++ b/src/test/java/org/littil/api/search/service/SearchServiceTest.java
@@ -1,7 +1,7 @@
 package org.littil.api.search.service;
 
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.mockito.InjectMock;
+import io.quarkus.test.InjectMock;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/org/littil/api/user/api/UserResourceTest.java
+++ b/src/test/java/org/littil/api/user/api/UserResourceTest.java
@@ -3,7 +3,7 @@ package org.littil.api.user.api;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.mockito.InjectMock;
+import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.mockito.InjectSpy;
 import io.quarkus.test.security.TestSecurity;
 import io.quarkus.test.security.oidc.Claim;

--- a/src/test/java/org/littil/api/userSetting/service/UserSettingServiceTest.java
+++ b/src/test/java/org/littil/api/userSetting/service/UserSettingServiceTest.java
@@ -1,7 +1,7 @@
 package org.littil.api.userSetting.service;
 
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.mockito.InjectMock;
+import io.quarkus.test.InjectMock;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
 import org.littil.api.userSetting.repository.UserSettingEntity;


### PR DESCRIPTION
Disabled unit tests failed because of incorrect mocking.

Also changed import for deprecated annotation @InjectMock.
See [Quarkus Migration Guide 3.2](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.2))