### PR TITLE
ignore SNYK-JAVA-IOVERTX-6209366

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,7 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities
+version: v1.25.0
+ignore:
+  SNYK-JAVA-IOVERTX-6209366:
+    - '*':
+        reason: No patch available yet
+        expires: 2024-02-07T00:00:00.004Z


### PR DESCRIPTION
Issues with no direct upgrade or patch:
  ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-IOVERTX-6209366] in io.vertx:vertx-core@4.4.6
    introduced by io.quarkus:quarkus-netty-deployment@3.6.5 > io.vertx:vertx-web@4.4.6 > io.vertx:vertx-core@4.4.6
  No upgrade or patch available

.snyk file added to ignore this vulnerability for a short periode.