### PR TITLE
Update ci.yml  madrapps/jacoco-report to v1.7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           path: target/generated/openapi.json
       - name: Publish code coverage to pull request
         if: ${{ github.actor != 'dependabot[bot]' }}
-        uses: madrapps/jacoco-report@v1.6.1
+        uses: madrapps/jacoco-report@v1.7.1
         with:
           paths: ${{ github.workspace }}/target/jacoco-report/jacoco.xml
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The old version v1.6.1 used a deprecated Node.js version and will be forced to run on node20