### PR TITLE
Change quarkus version from 3.17.4 to 3.16.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,8 @@
       <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
       <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
       <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-      <quarkus.platform.version>3.17.4</quarkus.platform.version>
+      <!-- quarkus 3.17.# is causing in issue in the frontend with the generated openapi.json -->
+      <quarkus.platform.version>3.16.4</quarkus.platform.version>
       <quarkus.package.type>fast-jar</quarkus.package.type>
       <surefire-plugin.version>3.5.2</surefire-plugin.version>
       <sonar.host.url>https://sonarcloud.io</sonar.host.url>


### PR DESCRIPTION
Quarkus version 3.17.# is causing an issue in the frontend with the generated openapi.json. See issue #421