### PR TITLE
LiTTiL-285 admin endpoint for user statistics

### DIFF
--- a/src/main/java/org/littil/api/guestTeacher/repository/GuestTeacherEntity.java
+++ b/src/main/java/org/littil/api/guestTeacher/repository/GuestTeacherEntity.java
@@ -22,6 +22,10 @@ import java.util.UUID;
 @Builder
 @Entity(name = "GuestTeacher")
 @Table(name = "guest_teacher")
+@NamedQuery(
+        name = "GuestTeacherEntity.countAndMaxCreatedAt",
+        query = "SELECT COUNT(e.id), MAX(e.createdDate) FROM GuestTeacher e "
+)
 public class GuestTeacherEntity extends AbstractAuditableEntity {
 
     @Id

--- a/src/main/java/org/littil/api/school/repository/SchoolEntity.java
+++ b/src/main/java/org/littil/api/school/repository/SchoolEntity.java
@@ -19,6 +19,10 @@ import java.util.UUID;
 @AllArgsConstructor
 @Entity(name = "School")
 @Table(name = "school")
+@NamedQuery(
+        name = "SchoolEntity.countAndMaxCreatedAt",
+        query = "SELECT COUNT(e.id), MAX(e.createdDate) FROM School e "
+)
 public class SchoolEntity extends AbstractAuditableEntity {
 
     @Id

--- a/src/main/java/org/littil/api/user/api/UserResource.java
+++ b/src/main/java/org/littil/api/user/api/UserResource.java
@@ -14,6 +14,8 @@ import org.littil.api.exception.ErrorResponse;
 import org.littil.api.user.service.User;
 import org.littil.api.user.service.UserMapper;
 import org.littil.api.user.service.UserService;
+import org.littil.api.user.service.UserStatistics;
+import org.littil.api.user.service.UserStatisticsService;
 
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
@@ -29,6 +31,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
+
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
@@ -42,6 +45,8 @@ import java.util.UUID;
 public class UserResource {
     @Inject
     UserService userService;
+    @Inject
+    UserStatisticsService userStatisticsService;
     @Inject
     UserMapper userMapper;
     @Inject
@@ -169,4 +174,22 @@ public class UserResource {
         userService.deleteUser(id);
         return Response.ok().build();
     }
+
+    @GET
+    @Path("statistics")
+    @RolesAllowed({"admin"})
+    @Operation(summary = "Get statistics of users")
+    @APIResponse(
+            responseCode = "200",
+            description = "Get statistics of users",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(type = SchemaType.ARRAY, implementation = UserStatistics.class)
+            )
+    )
+    public Response getUserStatistics() {
+        List<UserStatistics> userStatistics = userStatisticsService.getUserStatistics();
+        return Response.ok(userStatistics).build();
+    }
+
 }

--- a/src/main/java/org/littil/api/user/repository/UserEntity.java
+++ b/src/main/java/org/littil/api/user/repository/UserEntity.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
+import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
@@ -23,6 +24,11 @@ import java.util.UUID;
 @Builder
 @Entity(name = "User")
 @Table(name = "user")
+@NamedQuery(
+        name = "UserEntity.countAndMaxCreatedAt",
+        query = "SELECT COUNT(e.id), MAX(e.createdDate) FROM User e "
+)
+
 public class UserEntity extends AbstractAuditableEntity {
 
     @Id

--- a/src/main/java/org/littil/api/user/repository/UserStatisticsRepository.java
+++ b/src/main/java/org/littil/api/user/repository/UserStatisticsRepository.java
@@ -1,0 +1,54 @@
+package org.littil.api.user.repository;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Tuple;
+import org.jetbrains.annotations.NotNull;
+import org.littil.api.auth.service.AuthorizationType;
+import org.littil.api.user.service.UserStatistics;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@ApplicationScoped
+public class UserStatisticsRepository {
+
+    @Inject
+    EntityManager entityManager;
+
+    public List<UserStatistics> getUserStatistics() {
+        UserStatistics userStatistics = getStatisticsForUsers();
+        UserStatistics schoolStatistics = getStatisticsForSchools();
+        UserStatistics guestTeacherStatistics = getStatisticsForGuestTeachers();
+        return List.of(userStatistics, schoolStatistics,guestTeacherStatistics);
+    }
+
+    private UserStatistics getStatisticsForUsers() {
+        Tuple result = entityManager
+                .createNamedQuery("UserEntity.countAndMaxCreatedAt", Tuple.class)
+                .getSingleResult();
+        return mapToUserStatistics(AuthorizationType.USER, result);
+    }
+
+    private UserStatistics getStatisticsForSchools() {
+        Tuple result = entityManager
+                .createNamedQuery("SchoolEntity.countAndMaxCreatedAt", Tuple.class)
+                .getSingleResult();
+        return mapToUserStatistics(AuthorizationType.SCHOOL, result);
+    }
+
+    private UserStatistics getStatisticsForGuestTeachers() {
+        Tuple result = entityManager
+                .createNamedQuery("GuestTeacherEntity.countAndMaxCreatedAt", Tuple.class)
+                .getSingleResult();
+        return mapToUserStatistics(AuthorizationType.GUEST_TEACHER, result);
+    }
+
+    @NotNull
+    private static UserStatistics mapToUserStatistics(AuthorizationType authorizationType,Tuple result) {
+        Long count = result.get(0, Long.class);
+        LocalDateTime maxCreatedAt = result.get(1, LocalDateTime.class);
+        return new UserStatistics(authorizationType.getTokenValue(), count, maxCreatedAt);
+    }
+}

--- a/src/main/java/org/littil/api/user/service/UserStatistics.java
+++ b/src/main/java/org/littil/api/user/service/UserStatistics.java
@@ -1,0 +1,14 @@
+package org.littil.api.user.service;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+public class UserStatistics {
+    private String authorizationType;
+    private Long count;
+    private LocalDateTime lastCreated;
+}

--- a/src/main/java/org/littil/api/user/service/UserStatisticsService.java
+++ b/src/main/java/org/littil/api/user/service/UserStatisticsService.java
@@ -1,0 +1,24 @@
+package org.littil.api.user.service;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.littil.api.user.repository.*;
+
+import java.util.List;
+
+@ApplicationScoped
+@AllArgsConstructor
+@Slf4j
+public class UserStatisticsService {
+
+   UserStatisticsRepository repository;
+
+    @Transactional
+    public List<UserStatistics> getUserStatistics () {
+        return repository.getUserStatistics()
+                .stream()
+                .toList();
+    }
+}

--- a/src/test/java/org/littil/api/user/api/UserResourceTest.java
+++ b/src/test/java/org/littil/api/user/api/UserResourceTest.java
@@ -216,6 +216,39 @@ class UserResourceTest {
                 .statusCode(404);
     }
 
+    @Test
+    void givenGetUserStatisticsUnauthorized_thenShouldReturnForbidden() {
+        given()
+                .when()
+                .get("/statistics")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    @TestSecurity(user = "littil", roles = "admin")
+    @OidcSecurity(claims = {
+            @Claim(key = "https://littil.org/littil_user_id", value = "0ea41f01-cead-4309-871c-c029c1fe19bf") })
+    void givenGetUserStatisticsWithAdminRole_thenShouldReturnSuccesfully() {
+        given()
+                .when()
+                .get("/statistics")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    @TestSecurity(user = "littil", roles = "viewer")
+    @OidcSecurity(claims = {
+            @Claim(key = "https://littil.org/littil_user_id", value = "0ea41f01-cead-4309-871c-c029c1fe19bf") })
+    void givenGetUserStatisticsWithoutAdminRole_thenShouldReturnForbidden() {
+        given()
+                .when()
+                .get("/statistics")
+                .then()
+                .statusCode(403);
+    }
+
     private UserPostResource getDefaultUser() {
         UserPostResource user = new UserPostResource();
         user.setEmailAddress(RandomStringUtils.randomAlphabetic(10) + "@littil.org");

--- a/src/test/java/org/littil/api/user/repository/UserStatisticsRepositoryTest.java
+++ b/src/test/java/org/littil/api/user/repository/UserStatisticsRepositoryTest.java
@@ -1,0 +1,79 @@
+package org.littil.api.user.repository;
+
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.littil.api.auth.service.AuthorizationType;
+import org.littil.api.user.service.UserStatistics;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Tuple;
+import jakarta.persistence.TypedQuery;
+import java.time.LocalDateTime;
+import java.util.List;
+
+
+@QuarkusTest
+public class UserStatisticsRepositoryTest {
+
+    @Mock
+    EntityManager entityManager;
+
+    @InjectMocks
+    UserStatisticsRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testGetUserStatistics() {
+        // Arrange
+        Tuple userTuple = mock(Tuple.class);
+        Tuple schoolTuple = mock(Tuple.class);
+        Tuple guestTeacherTuple = mock(Tuple.class);
+
+        TypedQuery<Tuple> userQuery = mock(TypedQuery.class);
+        TypedQuery<Tuple> schoolQuery = mock(TypedQuery.class);
+        TypedQuery<Tuple> guestTeacherQuery = mock(TypedQuery.class);
+
+        when(entityManager.createNamedQuery("UserEntity.countAndMaxCreatedAt", Tuple.class)).thenReturn(userQuery);
+        when(entityManager.createNamedQuery("SchoolEntity.countAndMaxCreatedAt", Tuple.class)).thenReturn(schoolQuery);
+        when(entityManager.createNamedQuery("GuestTeacherEntity.countAndMaxCreatedAt", Tuple.class)).thenReturn(guestTeacherQuery);
+
+        when(userQuery.getSingleResult()).thenReturn(userTuple);
+        when(schoolQuery.getSingleResult()).thenReturn(schoolTuple);
+        when(guestTeacherQuery.getSingleResult()).thenReturn(guestTeacherTuple);
+
+        when(userTuple.get(0, Long.class)).thenReturn(10L);
+        when(userTuple.get(1, LocalDateTime.class)).thenReturn(LocalDateTime.of(2023, 1, 1, 0, 0));
+        when(schoolTuple.get(0, Long.class)).thenReturn(5L);
+        when(schoolTuple.get(1, LocalDateTime.class)).thenReturn(LocalDateTime.of(2023, 1, 1, 0, 0));
+        when(guestTeacherTuple.get(0, Long.class)).thenReturn(3L);
+        when(guestTeacherTuple.get(1, LocalDateTime.class)).thenReturn(LocalDateTime.of(2023, 1, 1, 0, 0));
+
+        UserStatistics expectedUserStatistics = new UserStatistics(AuthorizationType.USER.getTokenValue(), 10L, LocalDateTime.of(2023, 1, 1, 0, 0));
+        UserStatistics expectedSchoolStatistics = new UserStatistics(AuthorizationType.SCHOOL.getTokenValue(), 5L, LocalDateTime.of(2023, 1, 1, 0, 0));
+        UserStatistics expectedGuestTeacherStatistics = new UserStatistics(AuthorizationType.GUEST_TEACHER.getTokenValue(), 3L, LocalDateTime.of(2023, 1, 1, 0, 0));
+
+        // Act
+        List<UserStatistics> actualStatistics = repository.getUserStatistics();
+
+        // Assert
+        assertEquals(3, actualStatistics.size());
+        assertTrue(actualStatistics.contains(expectedUserStatistics));
+        assertTrue(actualStatistics.contains(expectedSchoolStatistics));
+        assertTrue(actualStatistics.contains(expectedGuestTeacherStatistics));
+
+
+    }
+}

--- a/src/test/java/org/littil/api/user/service/UserStatisticsServiceTest.java
+++ b/src/test/java/org/littil/api/user/service/UserStatisticsServiceTest.java
@@ -1,0 +1,50 @@
+package org.littil.api.user.service;
+
+import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.littil.api.user.repository.UserStatisticsRepository;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import jakarta.transaction.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+@QuarkusTest
+public class UserStatisticsServiceTest {
+
+    @Mock
+    UserStatisticsRepository repository;
+
+    @InjectMocks
+    UserStatisticsService service;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @Transactional
+    public void testGetUserStatistics() {
+        // Arrange
+        UserStatistics stat1 = new UserStatistics("role1", 2L, LocalDateTime.now());
+        UserStatistics stat2 = new UserStatistics("role2", 1L, LocalDateTime.now());
+        List<UserStatistics> expectedStatistics = Arrays.asList(stat1, stat2);
+
+        when(repository.getUserStatistics()).thenReturn(expectedStatistics);
+
+        // Act
+        List<UserStatistics> actualStatistics = service.getUserStatistics();
+
+        // Assert
+        assertEquals(expectedStatistics, actualStatistics);
+    }
+}


### PR DESCRIPTION
Endpoint /users/statistics added to collect statistics (count and lastCreated) for users, schools and guest_teachers.

Response : 
```
[
  { "authorizationType": "users", "count": 8, "lastCreated": "2024-12-14T10:56:28" },   
  { "authorizationType": "schools", "count": 3, "lastCreated": "2024-12-14T10:56:29" },   
  { "authorizationType": "guest_teachers", "count": 5, "lastCreated": "2024-12-14T10:56:28" }
]
```