### PR TITLE
clean pom.xml for dependencies that override version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,21 +47,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-oidc</artifactId>
         </dependency>
-        <dependency><!-- override graal-sdk because of vulnerability in version 22.3.0 (via quarkus-oicd) -->
-            <groupId>org.graalvm.sdk</groupId>
-            <artifactId>graal-sdk</artifactId>
-            <version>24.1.1</version>
-        </dependency>
-        <dependency><!-- override jose4j because of vulnerability in version 0.9.2 (via quarkus-oidc) -->
-            <groupId>org.bitbucket.b_c</groupId>
-            <artifactId>jose4j</artifactId>
-            <version>0.9.6</version>
-        </dependency>
-        <dependency><!-- override netty-handler because of vulnerability in version 4.1.86.Final (via io.quarkus:quarkus-mailer@2.16.7.Final -->
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler</artifactId>
-            <version>4.1.115.Final</version>
-        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Remove dependencies that where added to override versions used in quarkus because of vulnerability.