### PR TITLE
force open-api-version 3.0.3

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -41,6 +41,7 @@ quarkus:
     oidc-open-id-connect-url: ${org.littil.auth.tenant_uri}/authorize
     security-scheme-name: Auth0
     security-scheme: oauth2-implicit
+    open-api-version: 3.0.3
   oidc:
     roles:
       role-claim-path: '"https://littil.org/roles"'


### PR DESCRIPTION
force open-api-version to version 3.0.3 because version 3.1.0 is not supported yet in @openapitools/openapi-generator-cli in frontend