### PR TITLE
update configuration graalvm/setup-graalvm

### DIFF
--- a/.github/workflows/publish-build-container.yml
+++ b/.github/workflows/publish-build-container.yml
@@ -23,8 +23,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
-          version: '22.3.1'
           java-version: '17'
+          distribution: 'graalvm'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: s4u/setup-maven-action@v1.12.0


### PR DESCRIPTION
Change version to distibution following migration instructions on https://github.com/graalvm/setup-graalvm#migrating-from-graalvm-223-or-earlier-to-the-new-graalvm-for-jdk-17-and-later

fix for issue #311
