### PR TITLE
fix(quarkus): vervang deprecated quarkus.package.type / update CORS key

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,8 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.30.2</quarkus.platform.version>
-        <quarkus.package.type>fast-jar</quarkus.package.type>
+        <quarkus.package.jar.enabled>true</quarkus.package.jar.enabled>
+        <quarkus.package.jar.type>fast-jar</quarkus.package.jar.type>
         <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.organization>littil</sonar.organization>

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -23,7 +23,8 @@ quarkus:
   live-reload:
     instrumentation: true
   http:
-    cors: true
+    cors:
+      enabled: true
   datasource:
     db-kind: mariadb
   hibernate-orm:


### PR DESCRIPTION
- 'quarkus.package.type' vervangen door: quarkus.package.jar.enabled, quarkus.package.jar.type
- 'quarkus.http.cors' vervangen door 'quarkus.http.cors.enabled'
- warnings opgelost in build/config