### PR TITLE
chore(dependabot): update open pull request limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,6 @@ updates:
     schedule:
       interval: daily
       time: '04:00'
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 25
     labels:
       - dependencies


### PR DESCRIPTION
Increased `open-pull-requests-limit` to allow more concurrent updates.